### PR TITLE
Set default status for new tasks to open

### DIFF
--- a/lib/todo_backend/functions/task.ex
+++ b/lib/todo_backend/functions/task.ex
@@ -3,7 +3,7 @@ defmodule TodoBackend.Functions.Task do
   import Ecto.Changeset
 
   schema "tasks" do
-    field :status, :string
+    field :status, :string, default: "open"
     field :title, :string
 
     timestamps()
@@ -13,6 +13,6 @@ defmodule TodoBackend.Functions.Task do
   def changeset(task, attrs) do
     task
     |> cast(attrs, [:title, :status])
-    |> validate_required([:title, :status])
+    |> validate_required([:title])
   end
 end


### PR DESCRIPTION
Minor change as explained in the title. This change will ensure that we don't need to pass in a status: "open" for all new tasks, since it will be implied.